### PR TITLE
Fix/codeowners

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,4 +37,4 @@ jobs:
       - name: Release
         run: npm run release
         env:
-          GITHUB_TOKEN: ${{ secrets.ORG_CI_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @cbs-sports/video-github-admins @haversnail-cbs
+* @cbs-sports/video-github-admins @haversnail-cbs @semantic-release-bot


### PR DESCRIPTION
Possibly use the `semantic-release-bot` email as a CODEOWNER to prevent needing using a PAT for the ORG_CI_TOKEN