### PR TITLE
fix(action): use a supported runtime version

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -20,5 +20,5 @@ inputs:
     required: false
     default: ""
 runs:
-  using: "node18"
+  using: "node16"
   main: "dist/index.js"


### PR DESCRIPTION
highest supported version seems to be 16
https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions#runs